### PR TITLE
Added JourneyRef and StopId to diagnostics message due to requirement change

### DIFF
--- a/examples/mqtt/salediagnostics.json
+++ b/examples/mqtt/salediagnostics.json
@@ -5,6 +5,6 @@
    "nodAvailable":true,
    "sapiAvailable":false,
    "loggedIn":true,
-   "journeyRef":"RUT:Line:440",
+   "journeyId": "RUT:ServiceJourney:31-117215-13227462",
    "stopPlaceId":"NSR:StopPlace:59734"
 }

--- a/examples/mqtt/salediagnostics.json
+++ b/examples/mqtt/salediagnostics.json
@@ -1,8 +1,10 @@
 {
-   "eventTimestamp":"2020-04-22T10:30:03.548Z",
+   "eventTimestamp":"2020-04-28T13:49:50.814Z",
    "nfcReaderConnected":false,
    "printerConnected":true,
    "nodAvailable":true,
    "sapiAvailable":false,
-   "loggedIn":true
+   "loggedIn":true,
+   "journeyRef":"RUT:Line:440",
+   "stopPlaceId":"NSR:StopPlace:59734"
 }

--- a/schemas/mqtt/salediagnostics.json
+++ b/schemas/mqtt/salediagnostics.json
@@ -14,7 +14,7 @@
     "additionalProperties": false,
     "properties": {
         "eventTimestamp": {
-            "$id": "#/properties/timestamp",
+            "$id": "#/properties/eventTimestamp",
             "type": "string",
             "description": "Time of diagnostics generated",
             "format": "date-time"
@@ -56,7 +56,7 @@
             "description": "Last journeyId obtained by the app"
         },
         "stopPlaceId": {
-            "$id": "#/properties/printerStatus",
+            "$id": "#/properties/stopPlaceId",
             "type": "string",
             "description": "StopPlaceId obtained in NextStop that triggered this diagnostics message"
         }

--- a/schemas/mqtt/salediagnostics.json
+++ b/schemas/mqtt/salediagnostics.json
@@ -49,5 +49,16 @@
             "type": "string",
             "description": "Last status message from printer"
         }
+        ,
+        "journeyRef": {
+            "$id": "#/properties/journeyRef",
+            "type": "string",
+            "description": "Last JourneyRef obtained by the app"
+        },
+        "stopPlaceId": {
+            "$id": "#/properties/printerStatus",
+            "type": "string",
+            "description": "StopPlaceId obtained in NextStop that triggered this diagnostics message"
+        }
     }
 }

--- a/schemas/mqtt/salediagnostics.json
+++ b/schemas/mqtt/salediagnostics.json
@@ -50,10 +50,10 @@
             "description": "Last status message from printer"
         }
         ,
-        "journeyRef": {
-            "$id": "#/properties/journeyRef",
+        "journeyId": {
+            "$id": "#/properties/journeyId",
             "type": "string",
-            "description": "Last JourneyRef obtained by the app"
+            "description": "Last journeyId obtained by the app"
         },
         "stopPlaceId": {
             "$id": "#/properties/printerStatus",


### PR DESCRIPTION
This is to make the job easier for the guys intending to enrich the data in the messages later in the process, as we already have this info available in the app.