### PR TITLE
RS-2222 Changed from journeyId to journeyRef in RuterSalg diagnostics message…

### DIFF
--- a/examples/mqtt/salediagnostics.json
+++ b/examples/mqtt/salediagnostics.json
@@ -5,6 +5,6 @@
    "nodAvailable":true,
    "sapiAvailable":false,
    "loggedIn":true,
-   "journeyId": "RUT:ServiceJourney:31-117215-13227462",
+   "journeyRef": "42911-2020-05-25T16:42:00+02:00",
    "stopPlaceId":"NSR:StopPlace:59734"
 }

--- a/schemas/mqtt/salediagnostics.json
+++ b/schemas/mqtt/salediagnostics.json
@@ -50,10 +50,10 @@
             "description": "Last status message from printer"
         }
         ,
-        "journeyId": {
-            "$id": "#/properties/journeyId",
+        "journeyRef": {
+            "$id": "#/properties/journeyRef",
             "type": "string",
-            "description": "Last journeyId obtained by the app"
+            "description": "Last journeyRef obtained by the app"
         },
         "stopPlaceId": {
             "$id": "#/properties/stopPlaceId",


### PR DESCRIPTION
…, as this is more usable for the people using the data further down the line.